### PR TITLE
Greater context depth

### DIFF
--- a/markov-test.go
+++ b/markov-test.go
@@ -1,0 +1,36 @@
+package markov
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestStringGeneration(t *testing.T) {
+	g := NewGraph(1)
+	strlist := [4]string{"1 2 3 4 5", "1 3 5 4 2", "1 3 4 5 2", "2 3 4 5 1"}
+	for _, v := range strlist {
+		g.LoadPhrase(v)
+	}
+	arr := make([]string, 100)
+	notSeenBefore := false
+	for i := 0; i < len(arr); i++ {
+		arr[i] = g.GenerateMarkovString()
+	}
+	for _, v := range arr {
+		if !notSeenBefore { //Checking if this is a new string, not just a copy from the given data
+			inThisList := false
+			for _, st := range strlist {
+				if v == st {
+					inThisList = true
+				}
+			}
+			if !inThisList {
+				notSeenBefore = true
+			}
+		}
+		fmt.Println(v)
+	}
+	if !notSeenBefore {
+		t.Error("No new strings were ever generated")
+	}
+}

--- a/markov.go
+++ b/markov.go
@@ -42,8 +42,10 @@ func (graph *Graph) LoadPhrase(phrase string) {
 func (graph *Graph) GenerateMarkovString() string {
 	var ret string
 	var currLink *link = graph.starters.links[rand.Intn(len(graph.starters.links))]
+	ret += *currLink.value
+	currLink = currLink.links[rand.Intn(len(currLink.links))]
 	for currLink != nil {
-		ret += *currLink.value + " "
+		ret += " " + *currLink.value
 		currLink = currLink.links[rand.Intn(len(currLink.links))]
 	}
 	return ret

--- a/markov.go
+++ b/markov.go
@@ -20,9 +20,15 @@ type Graph struct {
 func (graph *Graph) LoadPhrase(phrase string) {
 	words := strings.Split(phrase, " ")
 	// Get the words in reverse order, just to make it easier to input the next word in the chain.
-	var prevVal *link = nil //Start prevVal as nil, to
+	var prevVal *link = nil //Start prevVal as nil, as the first word to appear will be the last one in the phrase.
 	for i := len(words) - 1; i >= 0; i-- {
-		prevVal = graph.loadWord(words[i], prevVal, (i == 0), make([]*string, 0)) //Last arg, if i is 0 then it is the start of the sentence, despite being at the end of the loop.
+		depthToGo := lesser(i, graph.contextDepth)
+		context := make([]*string, depthToGo)
+		for j := depthToGo; j > 0; j-- {
+			indexToGrab := i - j
+			context[j-1] = &words[indexToGrab]
+		}
+		prevVal = graph.loadWord(words[i], prevVal, (i == 0), context) //Last arg, if i is 0 then it is the start of the sentence, despite being at the end of the loop.
 	}
 }
 
@@ -40,8 +46,9 @@ func (graph *Graph) GenerateMarkovString() string {
 //private, implementation details.
 
 type link struct {
-	value string
-	links []*link
+	value   string
+	links   []*link
+	context []*string
 }
 
 type list struct {
@@ -75,4 +82,11 @@ func (graph *Graph) findInGraph(val string) *link {
 		}
 	}
 	return nil
+}
+
+func lesser(x int, y int) int {
+	if x > y {
+		return y
+	}
+	return x
 }

--- a/markov.go
+++ b/markov.go
@@ -96,7 +96,7 @@ func (graph *Graph) findInGraph(val string, context []*string) *link {
 				continue
 			}
 			for j, ctx := range v.context {
-				if ctx != context[j] {
+				if *ctx != *context[j] {
 					contextMatching = false
 				}
 			}

--- a/markov.go
+++ b/markov.go
@@ -9,8 +9,10 @@ import (
 
 //Graph is the generic holder of all of the data for a certain graph of words needed to generate a markov chain.
 type Graph struct {
-	starters list
-	allWords list
+	starters     list
+	allWords     list
+	strings      []string
+	contextDepth int
 }
 
 //LoadPhrase loads a whole phrase (be it a sentence, single word that someone said, or paragraph) into the graph.
@@ -20,7 +22,7 @@ func (graph *Graph) LoadPhrase(phrase string) {
 	// Get the words in reverse order, just to make it easier to input the next word in the chain.
 	var prevVal *link = nil //Start prevVal as nil, to
 	for i := len(words) - 1; i >= 0; i-- {
-		prevVal = graph.loadWord(words[i], prevVal, (i == 0)) //Last arg, if i is 0 then it is the start of the sentence, despite being at the end of the loop.
+		prevVal = graph.loadWord(words[i], prevVal, (i == 0), make([]*string, 0)) //Last arg, if i is 0 then it is the start of the sentence, despite being at the end of the loop.
 	}
 }
 
@@ -46,7 +48,9 @@ type list struct {
 	links []*link
 }
 
-func (graph *Graph) loadWord(val string, nextval *link, starter bool) *link {
+//loadWord loads a word into the respective graph. It creates a link if one doesn't exist,
+// and links the current word to both previous (if higher context is on) and next words.
+func (graph *Graph) loadWord(val string, nextval *link, starter bool, context []*string) *link {
 	l := graph.findInGraph(val)
 	if l == nil {
 		l = &link{

--- a/markov.go
+++ b/markov.go
@@ -15,6 +15,12 @@ type Graph struct {
 	contextDepth int
 }
 
+func NewGraph(depth int) *Graph {
+	var g Graph
+	g.contextDepth = depth
+	return &g
+}
+
 //LoadPhrase loads a whole phrase (be it a sentence, single word that someone said, or paragraph) into the graph.
 //Splits the phrase along spaces in order to load each word into the chain.
 func (graph *Graph) LoadPhrase(phrase string) {

--- a/markov.go
+++ b/markov.go
@@ -83,7 +83,18 @@ func (graph *Graph) loadWord(val string, nextval *link, starter bool, context []
 func (graph *Graph) findInGraph(val string, context []*string) *link {
 	for i, v := range graph.allWords.links {
 		if *v.value == val {
-			return graph.allWords.links[i]
+			contextMatching := true
+			if len(v.context) != len(context) {
+				continue
+			}
+			for j, ctx := range v.context {
+				if ctx != context[j] {
+					contextMatching = false
+				}
+			}
+			if contextMatching {
+				return graph.allWords.links[i]
+			}
 		}
 	}
 	return nil

--- a/markov_test.go
+++ b/markov_test.go
@@ -7,8 +7,7 @@ import (
 
 func TestStringGeneration(t *testing.T) {
 	g := NewGraph(1)
-	//strlist := []string{"1 2 3 4 5", "1 3 5 4 2", "1 3 4 5 2", "2 3 4 5 1", "1 5 3 2 4", "5 4 3 2 1", "4 3 1 2 5"}
-	strlist := []string{"1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"}
+	strlist := []string{"1 2 3 4 5", "1 3 5 4 2", "1 3 4 5 2", "2 3 4 5 1", "1 5 3 2 4", "5 4 3 2 1", "4 3 1 2 5"}
 	for _, v := range strlist {
 		g.LoadPhrase(v)
 	}
@@ -30,10 +29,6 @@ func TestStringGeneration(t *testing.T) {
 			}
 		}
 		fmt.Println(v)
-	}
-	for _, v := range g.allWords.links {
-		fmt.Printf("value: %s, ctx len: %d, ctx: %s, links: ", *v.value, len(v.context), safeval(v.context, 0))
-		fmt.Println(v.links)
 	}
 	if !notSeenBefore {
 		t.Error("No new strings were ever generated")

--- a/markov_test.go
+++ b/markov_test.go
@@ -32,9 +32,17 @@ func TestStringGeneration(t *testing.T) {
 		fmt.Println(v)
 	}
 	for _, v := range g.allWords.links {
-		fmt.Printf("value: %s, ctx len: %d\n", *v.value, len(v.context))
+		fmt.Printf("value: %s, ctx len: %d, ctx: %s, links: ", *v.value, len(v.context), safeval(v.context, 0))
+		fmt.Println(v.links)
 	}
 	if !notSeenBefore {
 		t.Error("No new strings were ever generated")
 	}
+}
+
+func safeval(list []*string, num int) string {
+	if num >= len(list) {
+		return ""
+	}
+	return *list[num]
 }

--- a/markov_test.go
+++ b/markov_test.go
@@ -7,7 +7,8 @@ import (
 
 func TestStringGeneration(t *testing.T) {
 	g := NewGraph(1)
-	strlist := [4]string{"1 2 3 4 5", "1 3 5 4 2", "1 3 4 5 2", "2 3 4 5 1"}
+	//strlist := []string{"1 2 3 4 5", "1 3 5 4 2", "1 3 4 5 2", "2 3 4 5 1", "1 5 3 2 4", "5 4 3 2 1", "4 3 1 2 5"}
+	strlist := []string{"1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"}
 	for _, v := range strlist {
 		g.LoadPhrase(v)
 	}
@@ -29,6 +30,9 @@ func TestStringGeneration(t *testing.T) {
 			}
 		}
 		fmt.Println(v)
+	}
+	for _, v := range g.allWords.links {
+		fmt.Printf("value: %s, ctx len: %d\n", *v.value, len(v.context))
 	}
 	if !notSeenBefore {
 		t.Error("No new strings were ever generated")


### PR DESCRIPTION
Increase the context that the markov chain can have access to. Currently the chain can only see the current word and picks the next one from anything it's ever seen come after that word. It should be able to see previous words as well, so that it can get closer to having proper grammar. However with too low data density this can cause overfitting, so the depth needs to be configurable. 